### PR TITLE
Fix the `touch` make targets.

### DIFF
--- a/html5ever-2016-08-25/makefile
+++ b/html5ever-2016-08-25/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/hyper.0.5.0/makefile
+++ b/hyper.0.5.0/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/inflate-0.1.0/makefile
+++ b/inflate-0.1.0/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/issue-32062-equality-relations-complexity/makefile
+++ b/issue-32062-equality-relations-complexity/makefile
@@ -1,6 +1,6 @@
 all:
 	$(RUSTC) issue-32062.rs -Ztime-passes -Zinput-stats
 touch:
-	rm hello
+	rm issue-32062
 clean:
-	rm hello
+	rm issue-32062

--- a/issue-32278-big-array-of-strings/makefile
+++ b/issue-32278-big-array-of-strings/makefile
@@ -1,6 +1,6 @@
 all:
 	$(RUSTC) big-array-of-strings.rs -Ztime-passes -Zinput-stats
 touch:
-	rm hello
+	rm big-array-of-strings
 clean:
-	rm hello
+	rm big-array-of-strings

--- a/jld-day15-parser/makefile
+++ b/jld-day15-parser/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/piston-image-0.10.3/makefile
+++ b/piston-image-0.10.3/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/regex.0.1.30/makefile
+++ b/regex.0.1.30/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock

--- a/rust-encoding-0.3.0/makefile
+++ b/rust-encoding-0.3.0/makefile
@@ -1,7 +1,7 @@
 all:
 	$(CARGO_BUILD)
 touch:
-	rm target/debug/*
+	rm -rf target/debug/*
 clean:
 	rm target -rf
 	rm Cargo.lock


### PR DESCRIPTION
Clearly these aren't getting wide used because most of them are wrong.
Some of them name the wrong file, and some of them omit a necessary
'-rf'.
