### PR TITLE
Tweak `make touch` for futures-rs-test-all.

### DIFF
--- a/futures-rs-test-all/makefile
+++ b/futures-rs-test-all/makefile
@@ -3,7 +3,7 @@
 all:
 	cargo rustc --test all --verbose -- -Ztime-passes -Zinput-stats
 touch:
-	rm -f target/debug/all-*
+	rm -rf target/debug
 clean:
 	rm target -rf
 	rm Cargo.lock


### PR DESCRIPTION
The `make touch` target for futures-rs-test-all is designed so that only
one crate is recompiled afterwards. But that means if you run `make`
with one rustc, then run `make touch`, then run `make` with another
rustc -- a fundamental use case when evaluating an optimization -- you
get an error about mismatched compilers.

This commit changes `make touch` to remove all the compiled code. That
avoids this problem. It doesn't change the benchmark much because it
only contains two crates, and the `log` crate (which is now recompiled
with this change) is much smaller than the main crate.
