### PR TITLE
Fix rust-encoding-0.3.0's `touch` target.

### DIFF
--- a/rust-encoding-0.3.0/makefile
+++ b/rust-encoding-0.3.0/makefile
@@ -3,6 +3,6 @@
 all:
 	cargo rustc -- $(CARGO_RUSTC_OPTS)
 touch:
-	find . -name '*.rs' | xargs touch
+	touch src/lib.rs
 clean:
 	cargo clean


### PR DESCRIPTION
Currently it causes multiple crates to be rebuilt. This commit changes
it so that only the `encoding` crate is rebuilt.
