### PR TITLE
Add $(CARGO_OPTS) to make `all` targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ multiple crates, each benchmark has one "crate of interest" which is the one
 whose compilation time is measured.
 
 Each benchmark has a makefile with the following targets.
-* `all`: builds the entire benchmark. The `CARGO_RUSTC_OPTS` environment
-  variable can be specified to pass extra arguments to rustc invocations.
+* `all`: builds the entire benchmark. The following environment variables can
+  be used to influence how it is built.
+  * `CARGO_OPTS`: extra arguments to the `cargo` invocation.
+  * `CARGO_RUSTC_OPTS`: extra arguments to `cargo rustc` invocations.
 * `touch`: touches or removes files in such a way that a subsequent `make`
   invocation will build only the crate of interest.
 * `clean`: removes all build artifacts.
@@ -16,5 +18,8 @@ site makes use of the `process.sh` script plus some auxiliary scripts not in
 this repository.
 
 Local runs comparing two different compilers can be performed with
-`compare.py`. This is useful when evaluating compile-time optimizations.
+`compare.py`. Invocation is simple:
+> `./compare.py <rustc1> <rustc2>`
+
+This is useful when evaluating compile-time optimizations.
 

--- a/futures-rs-test-all/makefile
+++ b/futures-rs-test-all/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc --test all -- $(CARGO_RUSTC_OPTS)
+	cargo rustc --test all $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	rm -f target/debug/all-*
 clean:

--- a/helloworld/makefile
+++ b/helloworld/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/html5ever-2016-08-25/makefile
+++ b/html5ever-2016-08-25/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/hyper.0.5.0/makefile
+++ b/hyper.0.5.0/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/inflate-0.1.0/makefile
+++ b/inflate-0.1.0/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/issue-32062-equality-relations-complexity/makefile
+++ b/issue-32062-equality-relations-complexity/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/issue-32278-big-array-of-strings/makefile
+++ b/issue-32278-big-array-of-strings/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/jld-day15-parser/makefile
+++ b/jld-day15-parser/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/piston-image-0.10.3/makefile
+++ b/piston-image-0.10.3/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/regex.0.1.30/makefile
+++ b/regex.0.1.30/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	find . -name '*.rs' | xargs touch
 clean:

--- a/rust-encoding-0.3.0/makefile
+++ b/rust-encoding-0.3.0/makefile
@@ -1,7 +1,7 @@
 .PHONY: all touch clean
 
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	touch src/lib.rs
 clean:

--- a/syntex-0.42.2-incr-clean/makefile
+++ b/syntex-0.42.2-incr-clean/makefile
@@ -10,7 +10,8 @@
 
 all:
 	RUSTFLAGS="-Z incremental=incr" \
-	    cargo rustc -p syntex_syntax -- $(CARGO_RUSTC_OPTS) -Z incremental-info
+	    cargo rustc -p syntex_syntax $(CARGO_OPTS) -- \
+	    $(CARGO_RUSTC_OPTS) -Z incremental-info
 touch:
 	cargo clean -p syntex_syntax
 clean:

--- a/syntex-0.42.2/makefile
+++ b/syntex-0.42.2/makefile
@@ -4,7 +4,7 @@
 # `../syntax-0.42.2-incr-clean/makefile` for some further notes.
 
 all:
-	cargo rustc -p syntex_syntax -- $(CARGO_RUSTC_OPTS)
+	cargo rustc -p syntex_syntax $(CARGO_OPTS) -- $(CARGO_RUSTC_OPTS)
 touch:
 	cargo clean -p syntex_syntax
 clean:


### PR DESCRIPTION
I have used env var this to pass '-v' argument to cargo in order to extract the rustc invocations that are being used for each benchmark. (Having the exact invocations is very useful when using Valgrind.)
