### PR TITLE
tweak scripts for rustbuild compatibility

### DIFF
--- a/process.sh
+++ b/process.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
+#
+# Using the rustc executable found in $RUSTC_DIR (as set by
+# `scripts/dirs.sh`), executes each of the benchmarks found in this
+# directory. See the README.md for comments on the protocol.
 
-if [ -z "$TIMES_DIR" ]; then
-    TIMES_DIR=/home/ncameron/times
-fi
+MYDIR=$(dirname $0)
+source "$MYDIR/scripts/dirs.sh"
 
-START=$(pwd)
-export SCRIPTS_DIR=${START}/scripts
 export CARGO_RUSTC_OPTS="-Ztime-passes -Zinput-stats"
 export PATH=$RUSTC_DIR/bin:$PATH
+export BENCH_DIR=$MYDIR
 
 echo TIMES_DIR=$TIMES_DIR
 echo SCRIPTS_DIR=$SCRIPTS_DIR
 
 # Check if user provided list of directories;
 # else process them all.
+cd $BENCH_DIR
 if [ "$1" != "" ]; then
     DIRS="$@"
 else
@@ -24,7 +27,7 @@ for dir in $DIRS; do
     if [[ -d $dir ]]; then
         echo "Processing $dir"
 
-        cd $START/$dir
+        cd $BENCH_DIR/$dir
         PATCHES=($(make patches))
         if [ ! "${PATCHES[*]}" ]; then
             PATCHES=('')
@@ -39,7 +42,7 @@ for dir in $DIRS; do
                 git show HEAD -s >$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 rustc --version >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 ls -l $(which rustc) >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
-                cd $START/$dir
+                cd $BENCH_DIR/$dir
                 echo "rustc: ./$dir$PATCH" >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 make all$PATCH >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 echo "done" >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
@@ -63,6 +66,6 @@ for dir in $DIRS; do
             git add "processed/$dir$PATCH--$DATE.json"
         done
 
-        cd $START
+        cd $BENCH_DIR
     fi
 done

--- a/process.sh
+++ b/process.sh
@@ -9,7 +9,6 @@ source "$MYDIR/scripts/dirs.sh"
 
 export CARGO_RUSTC_OPTS="-Ztime-passes -Zinput-stats"
 export PATH=$RUSTC_DIR/bin:$PATH
-export BENCH_DIR=$MYDIR
 
 echo TIMES_DIR=$TIMES_DIR
 echo SCRIPTS_DIR=$SCRIPTS_DIR

--- a/process.sh
+++ b/process.sh
@@ -37,6 +37,8 @@ for dir in $DIRS; do
             for PATCH in "${PATCHES[@]}"; do
                 cd $RUST_DIR
                 git show HEAD -s >$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
+                rustc --version >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
+                ls -l $(which rustc) >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 cd $START/$dir
                 echo "rustc: ./$dir$PATCH" >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log
                 make all$PATCH >>$TIMES_DIR/raw/$dir$PATCH--$DATE--$i.log

--- a/scripts/dirs.sh
+++ b/scripts/dirs.sh
@@ -1,0 +1,5 @@
+export TIMES_DIR=$HOME/times
+export RUST_DIR=$HOME/rust
+export BENCH_DIR=$HOME/benchmarks
+export SCRIPTS_DIR=$HOME/benchmarks/scripts
+

--- a/scripts/go.sh
+++ b/scripts/go.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#
+# The main script that kicks off data collection on the perf
+# server. It is meant to be run from the "benchmarks/scripts"
+# directory.
+
+MYDIR=$(dirname $0)
+
+# Load the various directories and so forth.
+source "$MYDIR/dirs.sh"
+
 while :; do
-    ./time.sh
+    $SCRIPTS_DIR/time.sh
 done

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -5,7 +5,7 @@
 MYDIR=$(dirname $0)
 source "$MYDIR/dirs.sh"
 
-cd #RUST_DIR
+cd $RUST_DIR
 
 echo "building"
 ./x.py build

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -8,28 +8,27 @@ SCRIPTS_DIR=/root/benchmarks/scripts
 START=$(pwd)
 
 echo "building"
+./x.py build
 
-./configure
-make rustc -j8
-
-export RUSTFLAGS_STAGE2="-Ztime-passes -Zinput-stats"
-
-for i in 0 1 2
-do
-    echo "building, round $i"
-    git show HEAD -s >$TIMES_DIR/raw/rustc--$DATE--$i.log
-    touch src/librustc_trans/lib.rs
-    make >>$TIMES_DIR/raw/rustc--$DATE--$i.log
-done
-
-echo "processing data"
-cd $TIMES_DIR
-python $SCRIPTS_DIR/process.py rustc $DATE 3
-for i in 0 1 2
-do
-    git add raw/rustc--$DATE--$i.log
-done
-git add processed/rustc--$DATE.json
+# This is the old code that used to measure bootstrap time.  It is
+# disabled because it has not been ported to work with rustbuild yet.
+#
+#export RUSTFLAGS_STAGE2="-Ztime-passes -Zinput-stats"
+#for i in 0 1 2
+#do
+#    echo "building, round $i"
+#    git show HEAD -s >$TIMES_DIR/raw/rustc--$DATE--$i.log
+#    touch src/librustc_trans/lib.rs
+#    make >>$TIMES_DIR/raw/rustc--$DATE--$i.log
+#done
+#echo "processing data"
+#cd $TIMES_DIR
+#python $SCRIPTS_DIR/process.py rustc $DATE 3
+#for i in 0 1 2
+#do
+#    git add raw/rustc--$DATE--$i.log
+#done
+#git add processed/rustc--$DATE.json
 
 echo "benchmarks"
 export RUSTC_DIR=$START/build/x86_64-unknown-linux-gnu/stage2

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -3,7 +3,7 @@
 
 TIMES_DIR=/root/times
 BENCH_DIR=/root/benchmarks
-SCRIPTS_DIR=/root/times-scripts
+SCRIPTS_DIR=/root/benchmarks/scripts
 
 START=$(pwd)
 

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+#
 # Benchmarks currently checked out Rust.
 
-TIMES_DIR=/root/times
-BENCH_DIR=/root/benchmarks
-SCRIPTS_DIR=/root/benchmarks/scripts
+MYDIR=$(dirname $0)
+source "$MYDIR/dirs.sh"
 
-START=$(pwd)
+cd #RUST_DIR
 
 echo "building"
 ./x.py build
@@ -34,7 +34,6 @@ echo "benchmarks"
 export RUSTC_DIR=$START/build/x86_64-unknown-linux-gnu/stage2
 export RUSTC=$RUSTC_DIR/bin/rustc
 export LD_LIBRARY_PATH=$RUSTC_DIR/lib
-export RUST_DIR=$START
 cd $BENCH_DIR
 ./process.sh
 

--- a/scripts/run_bench.sh
+++ b/scripts/run_bench.sh
@@ -32,7 +32,7 @@ done
 git add processed/rustc--$DATE.json
 
 echo "benchmarks"
-export RUSTC_DIR=$START/x86_64-unknown-linux-gnu/stage2
+export RUSTC_DIR=$START/build/x86_64-unknown-linux-gnu/stage2
 export RUSTC=$RUSTC_DIR/bin/rustc
 export LD_LIBRARY_PATH=$RUSTC_DIR/lib
 export RUST_DIR=$START

--- a/scripts/time.sh
+++ b/scripts/time.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Pulls current rust and benchmarks it.
+#
+# Pulls current rust and tracks the last version that we have
+# seen. When we see a new version, starts `run_bench.sh` to benchmark
+# it.
+
+MYDIR=$(dirname $0)
+source "$MYDIR/dirs.sh"
+
+cd $RUST_DIR
 
 echo "pulling master ($DATE)"
 git checkout master
@@ -17,4 +25,4 @@ do
 done
 
 export DATE=$(date +%F-%H-%M-%S)
-./run_bench.sh
+$SCRIPTS_DIR/run_bench.sh


### PR DESCRIPTION
These changes (I think) fix the scripts so they work with rustbuild. They disable bootstrap timing because I'm not sure the best way to re-enable that right now. Also, these changes move the knowledge of what directory goes where into `dirs.sh` and rejiggers the scripts so they should be startable from any directory.

cc @nrc @Mark-Simulacrum 